### PR TITLE
Misc crash fixes

### DIFF
--- a/site-generator.js
+++ b/site-generator.js
@@ -338,7 +338,7 @@ function updateMetadata(filepath, data) {
 	}
 
 	if (page.headerImage && path.parse(page.headerImage).root == '/') {
-		page.headerImage = new URL(page.headerImage, data.site.url).href
+		page.headerImage = new URL(page.headerImage, 'https://' + data.site.url).href
 	}
 
 	if (page.includeInRSS) {
@@ -356,7 +356,7 @@ function updateMetadata(filepath, data) {
 
 		const bskyPost =[
 			`new post: ${page.title}`,
-			new URL(page.url, data.site.url).href,
+			new URL(page.url, 'https://' + data.site.url).href,
 			page.title,
 			page.description,
 			new Blob([headerImg]),

--- a/site-generator.js
+++ b/site-generator.js
@@ -342,13 +342,18 @@ function updateMetadata(filepath, data) {
 	}
 
 	if (page.includeInRSS) {
-		rssFeed.addItem({
-			title: page.title,
-			description: page.description,
-			link: page.url,
-			date: page.date,
-			content: page.content
-		})
+		try {
+			rssFeed.addItem({
+				title: page.title,
+				description: page.description,
+				link: page.url,
+				date: page.date,
+				content: page.content
+			})
+		} catch (err) {
+			logger.info('failed to add RSS post...')
+			logger.info(err)
+		}
 	}
 
 	if (page.bskyPostId == 'tbd' && process.argv.includes('--deploy')) {


### PR DESCRIPTION
Opening this PR to collect any crash fixes. I'm not combing through your code to fix things that "might" crash, rather these are crashes actual users have encountered so far that I debugged because I'm a sicko.

So far:

1. Prepending `data.site.url` with `https://` when instantiating `URL`s because the base URL needs that bit
2. Wrapping `rssFeed.addItem` in a try catch in case any input values are missing or malformed (e.g. wrongly formatted date in the post data)

I'm taking a "minimal code change" approach to these cuz I don't wanna insert opinionated code (like adding validation), and also just trying to match your style like with the error logging. But if you want me to go nuts on something just let me know!

Feel free to merge or close and add these yourself since they're so simple. I'll add to this PR if it's still open or make a new one if I find other stuff.

Also: I don't know how to set up a proper dev environment for this repo so I've been editing the live site-generator.js in my installation to test.