### PR TITLE
Improve update check

### DIFF
--- a/main.js
+++ b/main.js
@@ -32,8 +32,8 @@ const IS_PLUS_MODE = false
 
 const CURRENT_VERSION = "0.9.5-beta"
 let latestVersion
-
-await getLatestVersion()
+let versionIsCurrent = true
+let versionCheckError = false
 
 const icon = nativeImage.createFromDataURL('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABJElEQVR4AayRsWrCUBSGT24plCyVPkJL6dZ2cVfIWrv2bUzWPolrOwfi7qJOiujsqIsIwej9LrmXaEwQ9MKfnPOfcz5ObpRceW4LmH0GrcVHkMzfgxDZ5ap86m4DBp6+/OSx47d0oYvwkMok2e/lyJf8OEDj2+8+vN1Lo+OLjvOyGJBNCm98kyqerLj628h2msrqX78nKXatmKHBAAiQgehhQOSXyABeh3HfNl86bGcMgGHPEweRilO4m8i2OMDzKG7XQRi2F/wyjsMSAGPniSOTW9m/Qw4kG/wkxMhtQJJ/VwnCvSx/17SgSDV7bQJ0BMBgvUyJa8Dj0zazFC+6a/bc+tRKAEw20SBPx2wTcT94p8O6LmcBFJCGhIi4SrWAqqGifwAAAP//2exw9QAAAAZJREFUAwBmLW4hL61AdQAAAABJRU5ErkJggg==')
 
@@ -105,7 +105,12 @@ app.whenReady().then(() => {
 	tray.setToolTip(displayTitle)
 	tray.setTitle(displayTitle)
 
-	isUpdateAvailable(true)
+	getLatestVersion().then(() => {
+		updateTrayMenu()
+		if(!versionIsCurrent && !versionCheckError) {
+			notifyUpdateAvailability()
+		}
+	})
 })
 
 function updateTrayMenu() {
@@ -263,16 +268,17 @@ function updateTrayMenu() {
 			{ type: 'separator' },
 			{
 				label: '🚨 NEW UPDATE AVAILABLE!!!',
-				visible: isUpdateAvailable(true),
+				visible: !versionIsCurrent,
 				click: () => {
 					shell.openExternal('https://iznaut.itch.io/bimbo')
 				}
 			},
 			{
 				label: 'check for updates',
-				visible: !isUpdateAvailable(true),
+				visible: versionIsCurrent,
 				click: async () => {
 					await getLatestVersion()
+					notifyUpdateAvailability()
 					updateTrayMenu()
 				},
 			},
@@ -372,27 +378,20 @@ async function getLatestVersion() {
 			latestVersion = (await tiny.get({url: "https://raw.githubusercontent.com/iznaut/bimbo/refs/heads/main/version"})).body
 		} catch(e) {
 			logger.info(`Error getting latest version: ${e}`)
+			versionCheckError = true
 		}
+	}
+	if(latestVersion) {
+		versionCheckError = false
+		const versionComparison = compareVersions(latestVersion, CURRENT_VERSION)
+		versionIsCurrent = versionComparison === 0
 	}
 }
 
-function isUpdateAvailable(noNotification = false) {
-	// if latest version could not be fetched, return false
-	if(latestVersion === undefined) {
-		return false
-	}
-	
-	let isNewVersion = compareVersions(latestVersion, CURRENT_VERSION)
-
-	// don't show "no updates" notification on startup
-	if (!isNewVersion && noNotification) {
-		return isNewVersion
-	}
-
-	new Notification({
-		title: config.BASE_NAME,
-		body: isNewVersion ? `version ${latestVersion} available on itch.io` : 'no updates available'
-	}).show()
-
-	return isNewVersion
+function notifyUpdateAvailability() {
+	const message = 
+		versionCheckError ? 'update check failed' : 
+		versionIsCurrent ? 'no updates available' : 
+		`version ${latestVersion} available on itch.io`
+	new Notification({ title: config.BASE_NAME, body: message }).show()
 }

--- a/main.js
+++ b/main.js
@@ -33,7 +33,7 @@ const IS_PLUS_MODE = false
 const CURRENT_VERSION = "0.9.5-beta"
 let latestVersion
 
-getLatestVersion()
+await getLatestVersion()
 
 const icon = nativeImage.createFromDataURL('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABJElEQVR4AayRsWrCUBSGT24plCyVPkJL6dZ2cVfIWrv2bUzWPolrOwfi7qJOiujsqIsIwej9LrmXaEwQ9MKfnPOfcz5ObpRceW4LmH0GrcVHkMzfgxDZ5ap86m4DBp6+/OSx47d0oYvwkMok2e/lyJf8OEDj2+8+vN1Lo+OLjvOyGJBNCm98kyqerLj628h2msrqX78nKXatmKHBAAiQgehhQOSXyABeh3HfNl86bGcMgGHPEweRilO4m8i2OMDzKG7XQRi2F/wyjsMSAGPniSOTW9m/Qw4kG/wkxMhtQJJ/VwnCvSx/17SgSDV7bQJ0BMBgvUyJa8Dj0zazFC+6a/bc+tRKAEw20SBPx2wTcT94p8O6LmcBFJCGhIi4SrWAqqGifwAAAP//2exw9QAAAAZJREFUAwBmLW4hL61AdQAAAABJRU5ErkJggg==')
 
@@ -365,12 +365,23 @@ async function initDeploymentPreset(menuItem) {
 }
 
 async function getLatestVersion() {
-	latestVersion = isDev() ?
-		fs.readFileSync('version-devtest', "utf-8").trim()
-		: (await tiny.get({url: "https://raw.githubusercontent.com/iznaut/bimbo/refs/heads/main/version"})).body
+	if(isDev()) {
+		latestVersion = fs.readFileSync('version-devtest', "utf-8").trim()
+	} else {
+		try {
+			latestVersion = (await tiny.get({url: "https://raw.githubusercontent.com/iznaut/bimbo/refs/heads/main/version"})).body
+		} catch(e) {
+			logger.info(`Error getting latest version: ${e}`)
+		}
+	}
 }
 
 function isUpdateAvailable(noNotification = false) {
+	// if latest version could not be fetched, return false
+	if(latestVersion === undefined) {
+		return false
+	}
+	
 	let isNewVersion = compareVersions(latestVersion, CURRENT_VERSION)
 
 	// don't show "no updates" notification on startup

--- a/main.js
+++ b/main.js
@@ -106,8 +106,8 @@ app.whenReady().then(() => {
 	tray.setTitle(displayTitle)
 
 	getLatestVersion().then(() => {
-		updateTrayMenu()
-		if(!versionIsCurrent && !versionCheckError) {
+		if(!versionIsCurrent) {
+			updateTrayMenu()
 			notifyUpdateAvailability()
 		}
 	})


### PR DESCRIPTION
The app is crashing on launch because `latestVersion` isn't assigned before being used to compare with the local version.

This PR rewrites the whole flow of version checking and notifications:

1. `getLatestVersion()` sets the `latestVersion` variable. If it fails to fetch the latest version, it sets `versionCheckError` to true. If it succeeds and there is a newer version available, it sets `versionIsCurrent` to false.
2. `getLatestVersion()` is run when the app is initialized. If there is an update, it will update the tray and pop a notification, consistent with the old behavior.
3. I separated the update notification into a new function `notifyUpdateAvailability()` to make things less tangled together. It will now also report if the update check failed (not on startup, only after an explicit "check for updates" click by the user).
